### PR TITLE
Add concurrency control and batching to orchestrator

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -14,3 +14,5 @@ enable_caching: true
 retrieval_cache_size: 512
 rerank_cache_size: 1024
 enable_metrics_logging: true
+orchestrator_concurrency: 8
+rerank_batch_size: 8


### PR DESCRIPTION
## Summary
- Introduce thread-safe caching with locks and add configurable rerank batch size
- Run question handling with configurable concurrency and per-question timeout, falling back to candidate source on timeout
- Log actual concurrency and expose new configuration options

## Testing
- `python3 scripts/run_all.py answer --pages data/pages.jsonl --faiss data/faiss.index --bm25 data/bm25.json --questions data/questions.jsonl --out answers_c1.json --config /tmp/cfg1.yaml` *(fails: No module named 'fitz')*
- `python3 - <<'PY'
import asyncio, yaml
from orchestrator.pipeline import run_batch
cfg = yaml.safe_load(open('/tmp/cfg1.yaml'))
asyncio.run(run_batch('data/questions.jsonl','data/pages.jsonl','data/faiss.index','data/faiss.index.meta.json','data/bm25.json',cfg,'answers_c1.json'))
PY` *(fails: No module named 'faiss')*
- `pip3 install faiss-cpu --quiet` *(fails: environment externally managed)*

------
https://chatgpt.com/codex/tasks/task_e_689e1d0c1a348324a6c692b461fbd9c2