### PR TITLE
Add deterministic concurrent question processing

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -6,6 +6,8 @@ rerank_in: 24
 rerank_out: 2
 answer_max_pages: 2
 timeout_per_q_seconds: 90
+orchestrator_concurrency: 8
+rerank_batch_size: 4
 cot_enabled_types: ["number", "compare", "aggregate"]
 number_tolerance_pct: 0.5
 language_mode: "auto"


### PR DESCRIPTION
## Summary
- add thread-pooled concurrency with per-question timeouts and stable ordering
- expose `orchestrator_concurrency` and `rerank_batch_size` config options
- batch re-ranker uses configurable batch size; metrics log configured concurrency

## Testing
- `python scripts/run_all.py answer --pages data/pages.jsonl --faiss data/faiss.index --faiss_meta data/faiss.index.meta.json --bm25 data/bm25.json --questions data/questions.jsonl --out answers8.json --config configs/default.yaml`
- `python scripts/run_all.py answer --pages data/pages.jsonl --faiss data/faiss.index --faiss_meta data/faiss.index.meta.json --bm25 data/bm25.json --questions data/questions.jsonl --out answers1.json --config /tmp/c1.yaml`
- `cat answers8.json`
- `cat answers1.json`
- `cat logs/metrics.jsonl`


------
https://chatgpt.com/codex/tasks/task_e_689e21fb6460832492aca92530d9ff1d