### PR TITLE
feat: add offline multilingual dense embeddings

### DIFF
--- a/index/build_dense.py
+++ b/index/build_dense.py
@@ -1,49 +1,251 @@
-import json, faiss, numpy as np, os, hashlib
-from tqdm import tqdm
+"""Construction and querying of a dense FAISS index.
 
-def dummy_embed(texts):
+The module prefers a multilingual SentenceTransformer model when available.
+When the library or model cannot be loaded, it falls back to a lightweight
+TF‑IDF + SVD (LSA) pipeline implemented with NumPy only.  In both cases the
+produced vectors are L2 normalised and deterministic for a given input.
+
+The command line interface and output file names remain backward compatible
+with the previous dummy implementation.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import pickle
+import random
+import re
+import hashlib
+from typing import Callable, Dict, Iterable, List, Tuple
+
+import faiss
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Determinism helpers
+np.random.seed(0)
+random.seed(0)
+try:  # pragma: no cover - torch is optional
+    import torch
+
+    torch.manual_seed(0)
+except Exception:  # pragma: no cover - keep going if torch isn't installed
+    pass
+
+
+BATCH_SIZE = int(os.environ.get("EMBED_BATCH_SIZE", 32))
+ST_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"
+LSA_DIM = 256
+
+
+# ---------------------------------------------------------------------------
+# Tokenisation and simple TF‑IDF + SVD implementation
+def _tokenise(text: str) -> List[str]:
+    return re.findall(r"\b\w+\b", text.lower())
+
+
+def _fit_lsa(texts: List[str], dim: int = LSA_DIM) -> Tuple[np.ndarray, Dict]:
+    tokens = [_tokenise(t) for t in texts]
+
+    vocab: Dict[str, int] = {}
+    df: Dict[str, int] = {}
+    for toks in tokens:
+        seen = set()
+        for tok in toks:
+            if tok not in vocab:
+                vocab[tok] = len(vocab)
+            if tok not in seen:
+                df[tok] = df.get(tok, 0) + 1
+                seen.add(tok)
+
+    n_docs = len(texts)
+    vocab_size = len(vocab)
+    idf = np.zeros(vocab_size, dtype=np.float32)
+    for tok, idx in vocab.items():
+        idf[idx] = np.log((n_docs + 1) / (df[tok] + 1)) + 1.0
+
+    X = np.zeros((n_docs, vocab_size), dtype=np.float32)
+    for i, toks in enumerate(tokens):
+        counts: Dict[int, int] = {}
+        for tok in toks:
+            counts[vocab[tok]] = counts.get(vocab[tok], 0) + 1
+        if counts:
+            max_tf = max(counts.values())
+            for idx, c in counts.items():
+                tf = c / max_tf
+                X[i, idx] = tf * idf[idx]
+
+    dim = min(dim, min(X.shape))
+    U, S, Vt = np.linalg.svd(X, full_matrices=False)
+    U = U[:, :dim]
+    S = S[:dim]
+    Vt = Vt[:dim, :]
+
+    for i in range(dim):  # deterministic sign
+        if Vt[i, 0] < 0:
+            U[:, i] *= -1
+            Vt[i, :] *= -1
+
+    X_red = U * S
+    X_red = X_red / (np.linalg.norm(X_red, axis=1, keepdims=True) + 1e-12)
+
+    embed_info = {
+        "type": "lsa",
+        "dim": int(dim),
+        "vocab": vocab,
+        "idf": idf.tolist(),
+        "vtd": base64.b64encode(pickle.dumps(Vt.T)).decode("utf-8"),
+    }
+    return X_red.astype("float32"), embed_info
+
+
+def _lsa_embed(texts: Iterable[str], vocab: Dict[str, int], idf: List[float], vtd: str) -> np.ndarray:
+    Vt_T = pickle.loads(base64.b64decode(vtd))
+    vocab_size = len(vocab)
+    idf_vec = np.array(idf, dtype=np.float32)
+
     vecs = []
     for t in texts:
-        h = np.frombuffer(hashlib.sha1(t.encode("utf-8")).digest(), dtype=np.uint8).astype("float32")
-        vecs.append(h)
-    X = np.vstack(vecs)
-    X = X / (np.linalg.norm(X, axis=1, keepdims=True) + 1e-9)
-    return X
+        toks = _tokenise(t)
+        counts: Dict[int, int] = {}
+        for tok in toks:
+            idx = vocab.get(tok)
+            if idx is not None:
+                counts[idx] = counts.get(idx, 0) + 1
 
-def build_faiss_index(pages_jsonl, out_index_path, out_meta_path):
-    texts, meta = [], []
+        vec = np.zeros(vocab_size, dtype=np.float32)
+        if counts:
+            max_tf = max(counts.values())
+            for idx, c in counts.items():
+                tf = c / max_tf
+                vec[idx] = tf * idf_vec[idx]
+        emb = vec @ Vt_T
+        emb = emb / (np.linalg.norm(emb) + 1e-12)
+        vecs.append(emb.astype("float32"))
+
+    return np.vstack(vecs)
+
+
+# ---------------------------------------------------------------------------
+# SentenceTransformer loading (if available)
+def _try_sentence_transformer() -> Tuple[Callable[[List[str]], np.ndarray], Dict] | Tuple[None, None]:
+    try:  # pragma: no cover - optional dependency
+        from sentence_transformers import SentenceTransformer
+
+        model = SentenceTransformer(ST_MODEL_NAME, device="cpu")
+        model.eval()
+
+        def encode(texts: List[str]) -> np.ndarray:
+            return model.encode(
+                texts,
+                batch_size=BATCH_SIZE,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+                normalize_embeddings=True,
+            ).astype("float32")
+
+        info = {"type": "st", "model": ST_MODEL_NAME}
+        return encode, info
+    except Exception:
+        return None, None
+
+
+# ---------------------------------------------------------------------------
+# Index construction and search
+def build_faiss_index(pages_jsonl: str, out_index_path: str, out_meta_path: str) -> Tuple[str, str]:
+    texts: List[str] = []
+    meta: List[Dict[str, str]] = []
     with open(pages_jsonl, "r", encoding="utf-8") as f:
         for line in f:
             rec = json.loads(line)
             texts.append(rec["text"])
             meta.append({"doc_id": rec["doc_id"], "page": rec["page"]})
-    X = dummy_embed(texts)
+
+    encoder, embed_info = _try_sentence_transformer()
+    if encoder is None:
+        X, embed_info = _fit_lsa(texts, LSA_DIM)
+    else:
+        parts = []
+        for i in range(0, len(texts), BATCH_SIZE):
+            parts.append(encoder(texts[i : i + BATCH_SIZE]))
+        X = np.vstack(parts)
+
     dim = X.shape[1]
     index = faiss.IndexFlatIP(dim)
     index.add(X)
     faiss.write_index(index, out_index_path)
+
     with open(out_meta_path, "w", encoding="utf-8") as f:
-        json.dump(meta, f, ensure_ascii=False, indent=2)
+        json.dump({"meta": meta, "embedding": embed_info}, f, ensure_ascii=False, indent=2)
+
     return out_index_path, out_meta_path
 
-def search_faiss(index_path, meta_path, query, top_k=10):
-    index = faiss.read_index(index_path)
+
+def _load_meta(meta_path: str) -> Tuple[List[Dict], Dict]:
     with open(meta_path, "r", encoding="utf-8") as f:
-        meta = json.load(f)
-    qv = dummy_embed([query])
+        meta_obj = json.load(f)
+    if isinstance(meta_obj, dict):
+        meta = meta_obj.get("meta", [])
+        embed_info = meta_obj.get("embedding", {})
+    else:  # backward compatibility with old meta format
+        meta = meta_obj
+        embed_info = {}
+    return meta, embed_info
+
+
+def _embed_query(query: str, embed_info: Dict) -> np.ndarray:
+    if embed_info.get("type") == "st":
+        try:  # pragma: no cover - optional dependency
+            from sentence_transformers import SentenceTransformer
+
+            model = SentenceTransformer(embed_info["model"], device="cpu")
+            model.eval()
+            return model.encode(
+                [query],
+                batch_size=1,
+                show_progress_bar=False,
+                convert_to_numpy=True,
+                normalize_embeddings=True,
+            ).astype("float32")
+        except Exception:
+            pass
+
+    if embed_info.get("type") == "lsa":
+        return _lsa_embed([query], embed_info["vocab"], embed_info["idf"], embed_info["vtd"])
+
+    # Fallback to hash-based embedding for legacy indices
+    h = np.frombuffer(hashlib.sha1(query.encode("utf-8")).digest(), dtype=np.uint8).astype("float32")
+    h = h / (np.linalg.norm(h) + 1e-12)
+    return h.reshape(1, -1)
+
+
+def search_faiss(index_path: str, meta_path: str, query: str, top_k: int = 10) -> List[Dict]:
+    index = faiss.read_index(index_path)
+    meta, embed_info = _load_meta(meta_path)
+    qv = _embed_query(query, embed_info)
     D, I = index.search(qv, top_k)
+
     res = []
     for score, idx in zip(D[0], I[0]):
+        if idx < 0:
+            continue
         m = meta[int(idx)]
         res.append({**m, "score_dense": float(score)})
     return res
 
+
 if __name__ == "__main__":
-    import argparse, os
+    import argparse
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--pages", required=True)
     ap.add_argument("--out_index", required=True)
     ap.add_argument("--out_meta", required=True)
     args = ap.parse_args()
+
     os.makedirs(os.path.dirname(args.out_index), exist_ok=True)
     build_faiss_index(args.pages, args.out_index, args.out_meta)
+


### PR DESCRIPTION
## Summary
- add deterministic multilingual dense embeddings with SentenceTransformer fallback to LSA
- normalise vectors and store embedding metadata for reproducible FAISS search
- skip empty FAISS results and maintain hybrid compatibility

## Testing
- `python ingest/parse_pdf.py --input corpus --out data/pages.jsonl`
- `python index/build_bm25.py --pages data/pages.jsonl --out data/bm25.json`
- `python index/build_dense.py --pages data/pages.jsonl --out_index data/faiss.index --out_meta data/faiss.index.meta.json`
- `python - <<'PY'
import faiss, numpy as np
idx=faiss.read_index('data/faiss.index')
xb=np.stack([idx.reconstruct(i) for i in range(idx.ntotal)])
print('shape', xb.shape)
print('norms', np.round(np.linalg.norm(xb, axis=1),3))
PY`
- `python - <<'PY'
from index.build_dense import search_faiss
from index.build_bm25 import search_bm25
print('dense:', search_faiss('data/faiss.index','data/faiss.index.meta.json','doc1', top_k=5))
print('bm25:', search_bm25('data/bm25.json','doc1'))
PY`
- `python - <<'PY'
from retriever.hybrid import hybrid_search
res = hybrid_search('doc1', 'data/faiss.index','data/faiss.index.meta.json','data/bm25.json', top_k_dense=5, top_k_bm25=5)
print(res)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689e2fcb02948324b13fa57201624aed