### PR TITLE
Add second-pass citation validation in pipeline

### DIFF
--- a/answers.json
+++ b/answers.json
@@ -1,7 +1,7 @@
 [
   {
     "question_id": 1,
-    "answer": 19.0,
+    "answer": "N/A",
     "sources": [
       {
         "document": "Rakhat__rahtp_2024_rus",

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -132,6 +132,15 @@ def answer_one(q, pages_path, faiss_index, faiss_meta, bm25_index, cfg, stats):
                     {"document": reranked[0]["doc_id"], "page": reranked[0]["page"]}
                 ],
             }
+        # Вторичная проверка источников: если не подтвердили, отдаём N/A
+        if not check_sources(ans, pages_store):
+            ans = {
+                "question_id": q["question_id"],
+                "answer": "N/A",
+                "sources": [
+                    {"document": reranked[0]["doc_id"], "page": reranked[0]["page"]}
+                ],
+            }
 
     elapsed_ms = (time.perf_counter() - start_ts) * 1000.0
     stats["latencies"].append(elapsed_ms)


### PR DESCRIPTION
## Summary
- enforce source substring/number check after rerank; fallback to N/A when evidence missing
- regenerate `answers.json`

## Testing
- `PYTHONPATH=. python tests/hybrid_invariants.py`
- `PYTHONPATH=. python tests/rerank_invariants.py`
- `PYTHONPATH=. python tests/dense_norm_check.py`
- `PYTHONPATH=. python tests/answers_schema_check.py answers.json`
- `PYTHONPATH=. python tests/evidence_probe.py answers.json`
- `PYTHONPATH=. python tests/cache_same_process.py`
- `python scripts/run_all.py ingest --input ./corpus --out ./data/pages.jsonl`
- `python scripts/run_all.py index --pages ./data/pages.jsonl --out_dense ./data/faiss.index --out_bm25 ./data/bm25.json`
- `python scripts/run_all.py answer --pages ./data/pages.jsonl --faiss ./data/faiss.index --bm25 ./data/bm25.json --questions ./data/questions.jsonl --out ./answers.json`


------
https://chatgpt.com/codex/tasks/task_e_689f007f4278832484d0c72fb4ebec16