### PR TITLE
Use truncated SVD with sparse TF-IDF in dense index

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ faiss-cpu>=1.8.0
 rank-bm25>=0.2.2
 rapidfuzz>=3.6
 PyMuPDF>=1.24
+scipy>=1.10


### PR DESCRIPTION
## Summary
- Replace NumPy SVD with truncated SVD (`svds`) over a sparse TF-IDF matrix
- Normalize embeddings and add SciPy dependency

## Testing
- `pytest -q`
- `python index/build_dense.py --pages data/pages.jsonl --out_index /tmp/tmp.index --out_meta /tmp/tmp.meta` *(fails: No module named 'scipy')*


------
https://chatgpt.com/codex/tasks/task_e_689f17cb0ab48324a350cf391a5cc670