### PR TITLE
feat: add multilingual dense and CE reranker fallback

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -17,3 +17,12 @@ enable_caching: true
 retrieval_cache_size: 512
 rerank_cache_size: 1024
 enable_metrics_logging: true
+dense_backend: auto                # auto|sbert|lsa
+dense_model_name: paraphrase-multilingual-MiniLM-L12-v2
+dense_device: auto                 # auto|cpu|cuda
+dense_max_batch: 64
+dense_normalize: true              # L2-нормировка эмбеддингов
+
+rerank_mode: auto                  # auto|ce|heuristic
+ce_model_name: cross-encoder/ms-marco-MiniLM-L-6-v2
+ce_max_batch: 32

--- a/index/build_dense.py
+++ b/index/build_dense.py
@@ -22,6 +22,7 @@ from typing import Callable, Dict, Iterable, List, Tuple
 
 import faiss
 import numpy as np
+import yaml
 
 
 # ---------------------------------------------------------------------------
@@ -47,7 +48,7 @@ def _tokenise(text: str) -> List[str]:
     return re.findall(r"\b\w+\b", text.lower())
 
 
-def _fit_lsa(texts: List[str], dim: int = LSA_DIM) -> Tuple[np.ndarray, Dict]:
+def _fit_lsa(texts: List[str], dim: int = LSA_DIM, normalize: bool = True) -> Tuple[np.ndarray, Dict]:
     from scipy.sparse import csr_matrix
     from scipy.sparse.linalg import svds
 
@@ -100,19 +101,21 @@ def _fit_lsa(texts: List[str], dim: int = LSA_DIM) -> Tuple[np.ndarray, Dict]:
             Vt[i, :] *= -1
 
     X_red = U * S
-    X_red = X_red / (np.linalg.norm(X_red, axis=1, keepdims=True) + 1e-12)
+    if normalize:
+        X_red = X_red / (np.linalg.norm(X_red, axis=1, keepdims=True) + 1e-12)
 
     embed_info = {
-        "type": "lsa",
+        "method": "lsa",
         "dim": int(dim),
         "vocab": vocab,
         "idf": idf.tolist(),
         "vtd": base64.b64encode(pickle.dumps(Vt.T)).decode("utf-8"),
+        "normalize": bool(normalize),
     }
     return X_red.astype("float32"), embed_info
 
 
-def _lsa_embed(texts: Iterable[str], vocab: Dict[str, int], idf: List[float], vtd: str) -> np.ndarray:
+def _lsa_embed(texts: Iterable[str], vocab: Dict[str, int], idf: List[float], vtd: str, normalize: bool = True) -> np.ndarray:
     Vt_T = pickle.loads(base64.b64decode(vtd))
     vocab_size = len(vocab)
     idf_vec = np.array(idf, dtype=np.float32)
@@ -133,7 +136,8 @@ def _lsa_embed(texts: Iterable[str], vocab: Dict[str, int], idf: List[float], vt
                 tf = c / max_tf
                 vec[idx] = tf * idf_vec[idx]
         emb = vec @ Vt_T
-        emb = emb / (np.linalg.norm(emb) + 1e-12)
+        if normalize:
+            emb = emb / (np.linalg.norm(emb) + 1e-12)
         vecs.append(emb.astype("float32"))
 
     return np.vstack(vecs)
@@ -141,23 +145,28 @@ def _lsa_embed(texts: Iterable[str], vocab: Dict[str, int], idf: List[float], vt
 
 # ---------------------------------------------------------------------------
 # SentenceTransformer loading (if available)
-def _try_sentence_transformer() -> Tuple[Callable[[List[str]], np.ndarray], Dict] | Tuple[None, None]:
+def _try_sentence_transformer(
+    model_name: str,
+    device: str,
+    batch_size: int,
+    normalize: bool,
+) -> Tuple[Callable[[List[str]], np.ndarray], Dict] | Tuple[None, None]:
     try:  # pragma: no cover - optional dependency
         from sentence_transformers import SentenceTransformer
 
-        model = SentenceTransformer(ST_MODEL_NAME, device="cpu")
+        model = SentenceTransformer(model_name, device=device)
         model.eval()
 
         def encode(texts: List[str]) -> np.ndarray:
             return model.encode(
                 texts,
-                batch_size=BATCH_SIZE,
+                batch_size=batch_size,
                 show_progress_bar=False,
                 convert_to_numpy=True,
-                normalize_embeddings=True,
+                normalize_embeddings=normalize,
             ).astype("float32")
 
-        info = {"type": "st", "model": ST_MODEL_NAME}
+        info = {"method": "sbert", "model": model_name, "normalize": bool(normalize)}
         return encode, info
     except Exception:
         return None, None
@@ -165,7 +174,39 @@ def _try_sentence_transformer() -> Tuple[Callable[[List[str]], np.ndarray], Dict
 
 # ---------------------------------------------------------------------------
 # Index construction and search
-def build_faiss_index(pages_jsonl: str, out_index_path: str, out_meta_path: str) -> Tuple[str, str]:
+def _resolve_device(device: str) -> str:
+    if device == "auto":
+        try:  # pragma: no cover - optional dependency
+            import torch
+
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        except Exception:
+            return "cpu"
+    return device
+
+
+def build_faiss_index(
+    pages_jsonl: str,
+    out_index_path: str,
+    out_meta_path: str,
+    cfg: Dict | None = None,
+) -> Tuple[str, str]:
+    if cfg is None:
+        try:
+            cfg_path = os.path.join(
+                os.path.dirname(__file__), "..", "configs", "default.yaml"
+            )
+            with open(cfg_path, "r", encoding="utf-8") as f:
+                cfg = yaml.safe_load(f)
+        except Exception:
+            cfg = {}
+
+    backend = cfg.get("dense_backend", "auto")
+    model_name = cfg.get("dense_model_name", ST_MODEL_NAME)
+    device = _resolve_device(cfg.get("dense_device", "auto"))
+    batch = int(cfg.get("dense_max_batch", BATCH_SIZE))
+    normalize = bool(cfg.get("dense_normalize", True))
+
     texts: List[str] = []
     meta: List[Dict[str, str]] = []
     with open(pages_jsonl, "r", encoding="utf-8") as f:
@@ -180,13 +221,19 @@ def build_faiss_index(pages_jsonl: str, out_index_path: str, out_meta_path: str)
                 }
             )
 
-    encoder, embed_info = _try_sentence_transformer()
+    encoder = None
+    embed_info = None
+    if backend != "lsa":
+        encoder, embed_info = _try_sentence_transformer(
+            model_name, device, batch, normalize
+        )
+
     if encoder is None:
-        X, embed_info = _fit_lsa(texts, LSA_DIM)
+        X, embed_info = _fit_lsa(texts, LSA_DIM, normalize)
     else:
         parts = []
-        for i in range(0, len(texts), BATCH_SIZE):
-            parts.append(encoder(texts[i : i + BATCH_SIZE]))
+        for i in range(0, len(texts), batch):
+            parts.append(encoder(texts[i : i + batch]))
         X = np.vstack(parts)
 
     dim = X.shape[1]
@@ -196,6 +243,32 @@ def build_faiss_index(pages_jsonl: str, out_index_path: str, out_meta_path: str)
 
     with open(out_meta_path, "w", encoding="utf-8") as f:
         json.dump({"meta": meta, "embedding": embed_info}, f, ensure_ascii=False, indent=2)
+
+    try:
+        os.makedirs("/tmp", exist_ok=True)
+        norms = np.linalg.norm(X, axis=1)
+        meta_log = {
+            "method": embed_info.get("method"),
+            "model": embed_info.get("model"),
+            "normalize": embed_info.get("normalize"),
+        }
+        with open("/tmp/dense.log", "w", encoding="utf-8") as lf:
+            lf.write(
+                json.dumps(
+                    {
+                        "ntotal": int(index.ntotal),
+                        "dim": int(dim),
+                        "norm_mean": float(norms.mean()),
+                        "norm_min": float(norms.min()),
+                        "norm_max": float(norms.max()),
+                        "meta": meta_log,
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+    except Exception:
+        pass
 
     return out_index_path, out_meta_path
 
@@ -213,7 +286,7 @@ def _load_meta(meta_path: str) -> Tuple[List[Dict], Dict]:
 
 
 def _embed_query(query: str, embed_info: Dict) -> np.ndarray:
-    if embed_info.get("type") == "st":
+    if embed_info.get("method") == "sbert":
         try:  # pragma: no cover - optional dependency
             from sentence_transformers import SentenceTransformer
 
@@ -224,13 +297,19 @@ def _embed_query(query: str, embed_info: Dict) -> np.ndarray:
                 batch_size=1,
                 show_progress_bar=False,
                 convert_to_numpy=True,
-                normalize_embeddings=True,
+                normalize_embeddings=embed_info.get("normalize", True),
             ).astype("float32")
         except Exception:
             pass
 
-    if embed_info.get("type") == "lsa":
-        return _lsa_embed([query], embed_info["vocab"], embed_info["idf"], embed_info["vtd"])
+    if embed_info.get("method") == "lsa":
+        return _lsa_embed(
+            [query],
+            embed_info["vocab"],
+            embed_info["idf"],
+            embed_info["vtd"],
+            embed_info.get("normalize", True),
+        )
 
     # Fallback to hash-based embedding for legacy indices
     h = np.frombuffer(hashlib.sha1(query.encode("utf-8")).digest(), dtype=np.uint8).astype("float32")

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -90,6 +90,9 @@ def answer_one(q, pages_path, faiss_index, faiss_meta, bm25_index, cfg, stats):
                 ctx_pages,
                 top_m=len(ctx_pages),
                 batch_size=cfg.get("rerank_batch_size", 4),
+                mode=cfg.get("rerank_mode", "auto"),
+                ce_model_name=cfg.get("ce_model_name", "cross-encoder/ms-marco-MiniLM-L-6-v2"),
+                ce_max_batch=cfg.get("ce_max_batch", 32),
             )
             for r in reranked_all:
                 key = (query_hash, r["doc_id"], r["page"])
@@ -104,6 +107,9 @@ def answer_one(q, pages_path, faiss_index, faiss_meta, bm25_index, cfg, stats):
             ctx_pages,
             top_m=cfg.get("rerank_out", cfg["answer_max_pages"]),
             batch_size=cfg.get("rerank_batch_size", 4),
+            mode=cfg.get("rerank_mode", "auto"),
+            ce_model_name=cfg.get("ce_model_name", "cross-encoder/ms-marco-MiniLM-L-6-v2"),
+            ce_max_batch=cfg.get("ce_max_batch", 32),
         )
 
     ans = generate_answer(q, reranked, atype)
@@ -124,6 +130,9 @@ def answer_one(q, pages_path, faiss_index, faiss_meta, bm25_index, cfg, stats):
             ctx_pages,
             top_m=min(len(ctx_pages), cfg.get("rerank_out", cfg["answer_max_pages"]) + 1),
             batch_size=cfg.get("rerank_batch_size", 4),
+            mode=cfg.get("rerank_mode", "auto"),
+            ce_model_name=cfg.get("ce_model_name", "cross-encoder/ms-marco-MiniLM-L-6-v2"),
+            ce_max_batch=cfg.get("ce_max_batch", 32),
         )
         ans = generate_answer(q, reranked, atype)
         try:

--- a/retriever/rerank.py
+++ b/retriever/rerank.py
@@ -1,111 +1,151 @@
-"""Offline page re-ranking utilities.
-
-This module implements a deterministic re-ranker that scores candidate pages
-purely with local algorithms (no network calls).  It combines a simple BM25
-lexical score with a fuzzy matching score and normalises the result to the
-[0, 1] range.  Pages are processed in batches to satisfy the exercise
-requirements.
-"""
+"""Offline page re-ranking utilities with optional CrossEncoder support."""
 
 from __future__ import annotations
 
-from typing import List, Dict
+from typing import Dict, List, Tuple
 
+import os
+import random
+import numpy as np
 from rapidfuzz import fuzz
 from rank_bm25 import BM25Okapi
-import os
 
 os.makedirs("/tmp", exist_ok=True)
-with open("/tmp/rerank.log", "w", encoding="utf-8") as _rf:
-    _rf.write("OK: rerank deterministic sorted [0,1]\n")
+open("/tmp/rerank.log", "w", encoding="utf-8").close()
+
+random.seed(0)
+np.random.seed(0)
+try:  # pragma: no cover - torch is optional
+    import torch
+
+    torch.manual_seed(0)
+except Exception:  # pragma: no cover
+    pass
+
+_CE_MODEL = None
+_CE_FAILED = False
 
 
 def _tokenize(text: str) -> List[str]:
-    """Very small tokenizer used for BM25.
-
-    The baseline environment does not include heavy NLP libraries, so we fall
-    back to a simple whitespace/lowecase tokenizer which is deterministic and
-    sufficient for the benchmark.
-    """
-
     return text.lower().split()
 
 
-def rerank(query: str, pages: List[Dict], top_m: int = 2, batch_size: int = 4):
-    """Re-rank candidate pages for a given query.
+def _load_ce(model_name: str) -> Tuple[object, bool]:
+    global _CE_MODEL, _CE_FAILED
+    if _CE_MODEL is None and not _CE_FAILED:
+        try:  # pragma: no cover - optional dependency
+            from sentence_transformers import CrossEncoder
 
-    Parameters
-    ----------
-    query: str
-        User question/query string.
-    pages: list of dicts
-        Each element must contain at least ``{"doc_id", "page", "text"}``.
-    top_m: int
-        Number of top pages to return.
-    batch_size: int
-        Number of pages to process in one batch (>=4 preferred).
+            _CE_MODEL = CrossEncoder(model_name, device="cpu")
+            _CE_MODEL.eval()
+        except Exception:
+            _CE_FAILED = True
+    return _CE_MODEL, not _CE_FAILED
 
-    Returns
-    -------
-    list of dicts
-        The top ``top_m`` pages augmented with an ``rr_score`` field in
-        ``[0, 1]``.  Sorting is deterministic and ties are broken by
-        ``(doc_id, page)``.
-    """
 
+def rerank(
+    query: str,
+    pages: List[Dict],
+    top_m: int = 2,
+    batch_size: int = 4,
+    *,
+    mode: str = "auto",
+    ce_model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    ce_max_batch: int = 32,
+):
     if not pages:
         return []
 
-    # --- BM25 lexical score -------------------------------------------------
-    tokenized_pages: List[List[str]] = []
-    for i in range(0, len(pages), batch_size):
-        batch = pages[i : i + batch_size]
-        for p in batch:
-            tokenized_pages.append(_tokenize(p["text"]))
+    ce_model = None
+    mode_used = "heuristic"
+    if mode in {"auto", "ce"}:
+        ce_model, ok = _load_ce(ce_model_name)
+        if ok and ce_model is not None:
+            mode_used = "ce"
+        elif mode == "ce":
+            try:
+                import logging
 
-    bm25 = BM25Okapi(tokenized_pages)
-    query_tokens = _tokenize(query)
-    bm25_scores = bm25.get_scores(query_tokens)
+                logging.error("CrossEncoder unavailable, falling back to heuristic")
+            except Exception:
+                pass
 
-    max_bm25 = max(bm25_scores)
-    min_bm25 = min(bm25_scores)
-    if max_bm25 == min_bm25:
-        bm25_norm = [0.0] * len(bm25_scores)
+    if mode_used == "ce" and ce_model is not None:
+        pairs = [(query, p["text"]) for p in pages]
+        scores: List[float] = []
+        for i in range(0, len(pairs), ce_max_batch):
+            part = pairs[i : i + ce_max_batch]
+            preds = ce_model.predict(part, convert_to_numpy=True, show_progress_bar=False)
+            scores.extend(preds.tolist())
+
+        arr = np.array(scores, dtype=float)
+        if arr.size:
+            lo = arr.min()
+            hi = arr.max()
+            if hi - lo < 1e-9:
+                arr = np.zeros_like(arr)
+            else:
+                arr = (arr - lo) / (hi - lo)
+        final_scores = arr.tolist()
+
+        results = []
+        for p, s in zip(pages, final_scores):
+            results.append({**p, "rr_score": float(s)})
+
     else:
-        bm25_norm = [
-            (s - min_bm25) / (max_bm25 - min_bm25) for s in bm25_scores
+        # --- BM25 lexical score -------------------------------------------------
+        tokenized_pages: List[List[str]] = []
+        for i in range(0, len(pages), batch_size):
+            batch = pages[i : i + batch_size]
+            for p in batch:
+                tokenized_pages.append(_tokenize(p["text"]))
+
+        bm25 = BM25Okapi(tokenized_pages)
+        query_tokens = _tokenize(query)
+        bm25_scores = bm25.get_scores(query_tokens)
+
+        max_bm25 = max(bm25_scores)
+        min_bm25 = min(bm25_scores)
+        if max_bm25 == min_bm25:
+            bm25_norm = [0.0] * len(bm25_scores)
+        else:
+            bm25_norm = [
+                (s - min_bm25) / (max_bm25 - min_bm25) for s in bm25_scores
+            ]
+
+        # --- Fuzzy score ---------------------------------------------------------
+        fuzzy_scores = [0.0] * len(pages)
+        for i in range(0, len(pages), batch_size):
+            batch = pages[i : i + batch_size]
+            for j, p in enumerate(batch, start=i):
+                fuzzy_scores[j] = fuzz.partial_ratio(
+                    query.lower(), p["text"].lower()
+                ) / 100.0
+
+        # --- Combine and normalise ----------------------------------------------
+        combined = [
+            (bm25_norm[i] + fuzzy_scores[i]) / 2.0 for i in range(len(pages))
         ]
 
-    # --- Fuzzy score ---------------------------------------------------------
-    fuzzy_scores = [0.0] * len(pages)
-    for i in range(0, len(pages), batch_size):
-        batch = pages[i : i + batch_size]
-        for j, p in enumerate(batch, start=i):
-            fuzzy_scores[j] = fuzz.partial_ratio(
-                query.lower(), p["text"].lower()
-            ) / 100.0
+        max_c = max(combined)
+        min_c = min(combined)
+        if max_c == min_c:
+            final_scores = [0.0] * len(combined)
+        else:
+            final_scores = [(s - min_c) / (max_c - min_c) for s in combined]
 
-    # --- Combine and normalise ----------------------------------------------
-    combined = [(bm25_norm[i] + fuzzy_scores[i]) / 2.0 for i in range(len(pages))]
-
-    max_c = max(combined)
-    min_c = min(combined)
-    if max_c == min_c:
-        final_scores = [0.0] * len(combined)
-    else:
-        final_scores = [(s - min_c) / (max_c - min_c) for s in combined]
-
-    # Attach scores and sort deterministically
-    results = []
-    for i, p in enumerate(pages):
-        results.append({**p, "rr_score": float(final_scores[i])})
+        results = []
+        for i, p in enumerate(pages):
+            results.append({**p, "rr_score": float(final_scores[i])})
 
     results.sort(key=lambda x: (-x["rr_score"], x["doc_id"], x["page"]))
-
     out = results[:top_m]
+
     try:
         with open("/tmp/rerank.log", "a", encoding="utf-8") as f:
-            f.write(f"in={len(pages)} out={len(out)} sorted [0,1]\n")
+            f.write(
+                f"mode={mode_used} in={len(pages)} out={len(out)} sorted [0,1]\n"
+            )
     except Exception:
         pass
 
@@ -114,7 +154,6 @@ def rerank(query: str, pages: List[Dict], top_m: int = 2, batch_size: int = 4):
 
 # Backwards compatibility for existing orchestrator imports
 llm_like_rerank = rerank
-
 
 __all__ = ["rerank", "llm_like_rerank"]
 


### PR DESCRIPTION
## Summary
- support configurable dense embeddings with SentenceTransformer or LSA fallback
- add optional CrossEncoder-based reranking with heuristic fallback
- log dense, hybrid and rerank metadata for determinism

## Testing
- `python scripts/run_all.py index  --pages data/pages.jsonl --out_dense data/faiss.index --out_bm25 data/bm25.json`
- `python scripts/run_all.py answer --pages data/pages.jsonl --faiss data/faiss.index --bm25 data/bm25.json --questions data/questions.jsonl --out answers.json`
- `python local_verifier/tests/answers_schema_check.py answers.json`
- `python local_verifier/tests/evidence_probe.py answers.json --pages data/pages.jsonl`
- `python local_verifier/tests/dense_norm_check.py data/faiss.index`
- `python local_verifier/tests/hybrid_invariants.py`
- `python local_verifier/tests/rerank_invariants.py`
- `python local_verifier/tests/cache_same_process.py`


------
https://chatgpt.com/codex/tasks/task_e_689f2d9fce5c832499c805844691914d